### PR TITLE
Add an rpm package building system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ config/configure.in
 x-tools
 .config.*
 *.bz2
-
+lazy-newb-pack-*.src.rpm
+x86_64/*.rpm

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ x-tools
 *.bz2
 *.src.rpm
 x86_64/*.rpm
+.build-*.fc??.log

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ config/configure.in
 x-tools
 .config.*
 *.bz2
-lazy-newb-pack-*.src.rpm
+*.src.rpm
 x86_64/*.rpm

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Yet another DF LazyNewbPack builder for Linux/MacOS.
 
 The pack is ready to use in: `.build/src/lnp-x.xx` (and can be moved elsewhere)
 
+Optionally, you can also build an rpm package for Fedora by running:
+```bash
+fedpkg --release f32 local # Replace f32 for the version of fedora for which you want to build the pack
+```
+
+After building it, the binary rpm package can be found in `x86_64/lazy-newb-pack-*.*.x86_64.rpm`.
+
 ### Features:
 Components of the pack are downloaded and built from their original repository. No prebuilt binaries from Armok knows where!  
 Does include:  

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Yet another DF LazyNewbPack builder for Linux/MacOS.
 ### Usage:
 `./configure --prefix=$PWD && make install`  
 -> configures the tool for your system and install in local directory (`./bin/`)  
-`bin/lnp-forge menuconfig`  
+`./bin/lnp-forge menuconfig`  
 -> change DF version and other stuff (optional)  
-`bin/lnp-forge build`  
+`./bin/lnp-forge build`  
 -> downloads and builds components of your LazyNewbPack  
 
 The pack is ready to use in: `.build/src/lnp-x.xx` (and can be moved elsewhere)

--- a/fedora.spec
+++ b/fedora.spec
@@ -1,0 +1,48 @@
+# Prevent failure of rpmbuild when mangling shebangs (not entirely sure why the script fails but I believe it's linked to some packaged files having spaces in their filenames, there's an unfixed filezilla bug on that)
+%undefine __brp_mangle_shebangs
+
+Name:           lazy-newb-pack
+Version:        0.1
+Release:        1%{?dist}
+Summary:        McArcady's Lazy Newb Pack for Dwarf Fortress
+
+License:        Multiple
+URL:            https://github.com/McArcady/lnp-forge
+BuildArch:      x86_64
+
+BuildRequires:  gperf, qt5-qtbase-devel, ninja-build, qt5-qtdeclarative-devel
+Requires:       SDL, SDL_image, SDL_ttf, gtk2-devel, openal-soft, alsa-lib, alsa-plugins-pulseaudio, mesa-dri-drivers, python, gnome-terminal, perl, perl-XML-LibXML, perl-XML-LibXSLT, mercurial, help2man, git, java-1.8.0-openjdk, python3-tkinter, ncurses-devel, zlib-devel, mesa-libGL-devel, gcc-c++, qt5-qttools, cmake, dos2unix, texinfo
+
+%description
+A ready-to-go rpm package of McArcady's Lazy Newb Pack for Dwarf Fortress
+
+%build
+./configure --prefix=$PWD && make install
+./bin/lnp-forge build
+cat > ./.build/src/lnp-0.14/PyLNP.user <<EOF
+{
+  "updateDays": 0, 
+  "terminal": "nohup gnome-terminal -x", 
+  "terminal_type": "Custom command", 
+  "tkgui_height": 737, 
+  "tkgui_width": 435
+}
+EOF
+
+%install
+mkdir -p %{buildroot}/%{_datadir}
+cp -r ./.build/src/lnp-0.14 %{buildroot}/%{_datadir}/%{name}
+# This could be applied more selectively but, at the moment, it works
+chmod -R 777 %{buildroot}/%{_datadir}/%{name}
+# See https://lists.fedoraproject.org/pipermail/packaging/2012-December/008792.html
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+mkdir -p %{buildroot}/%{_bindir}
+ln -rs %{buildroot}/%{_datadir}/%{name}/startlnp.sh %{buildroot}/%{_bindir}/%{name}
+
+%files
+%{_bindir}/%{name}
+"%{_datadir}/%{name}/"
+
+%changelog
+* Sat Jun 23 2020 Albert <github@albert.sh>
+- 

--- a/fedora.spec
+++ b/fedora.spec
@@ -10,8 +10,8 @@ License:        Multiple
 URL:            https://github.com/McArcady/lnp-forge
 BuildArch:      x86_64
 
-BuildRequires:  gperf, qt5-qtbase-devel, ninja-build, qt5-qtdeclarative-devel, perl-IO-Compress, perl, perl-XML-LibXML, perl-XML-LibXSLT, mercurial, git, cmake, gcc-c++, zlib-devel, mesa-libGL-devel, ncurses-devel, gtk2-devel, dos2unix, texinfo, help2man
-Requires:       SDL, SDL_image, SDL_ttf, openal-soft, alsa-lib, alsa-plugins-pulseaudio, mesa-dri-drivers, python, gnome-terminal, java-1.8.0-openjdk, python3-tkinter, qt5-qttools
+BuildRequires:  gperf, qt5-qtbase-devel, ninja-build, qt5-qtdeclarative-devel, perl-IO-Compress, perl, perl-XML-LibXML, perl-XML-LibXSLT, mercurial, git, cmake, gcc-c++, zlib-devel, mesa-libGL-devel, ncurses-devel, dos2unix, texinfo, help2man
+Requires:       SDL, SDL_image, SDL_ttf, gtk2-devel, openal-soft, alsa-lib, alsa-plugins-pulseaudio, mesa-dri-drivers, python, gnome-terminal, java-1.8.0-openjdk, python3-tkinter, qt5-qttools
 
 %description
 A ready-to-go rpm package of McArcady's Lazy Newb Pack for Dwarf Fortress

--- a/fedora.spec
+++ b/fedora.spec
@@ -1,7 +1,7 @@
-# Prevent failure of rpmbuild when mangling shebangs (not entirely sure why the script fails but I believe it's linked to some packaged files having spaces in their filenames, there's an unfixed filezilla bug on that)
+# Prevent failure of rpmbuild when mangling shebangs (I believe this is caused by https://bugzilla.redhat.com/show_bug.cgi?id=1541318, marked WONTFIX)
 %undefine __brp_mangle_shebangs
 
-Name:           lazy-newb-pack
+Name:           linux-dwarf-pack
 Version:        0.1
 Release:        1%{?dist}
 Summary:        McArcady's Lazy Newb Pack for Dwarf Fortress
@@ -10,8 +10,8 @@ License:        Multiple
 URL:            https://github.com/McArcady/lnp-forge
 BuildArch:      x86_64
 
-BuildRequires:  gperf, qt5-qtbase-devel, ninja-build, qt5-qtdeclarative-devel
-Requires:       SDL, SDL_image, SDL_ttf, gtk2-devel, openal-soft, alsa-lib, alsa-plugins-pulseaudio, mesa-dri-drivers, python, gnome-terminal, perl, perl-XML-LibXML, perl-XML-LibXSLT, mercurial, help2man, git, java-1.8.0-openjdk, python3-tkinter, ncurses-devel, zlib-devel, mesa-libGL-devel, gcc-c++, qt5-qttools, cmake, dos2unix, texinfo
+BuildRequires:  gperf, qt5-qtbase-devel, ninja-build, qt5-qtdeclarative-devel, perl-IO-Compress, perl, perl-XML-LibXML, perl-XML-LibXSLT, mercurial, git, cmake, gcc-c++, zlib-devel, mesa-libGL-devel, ncurses-devel, gtk2-devel, dos2unix, texinfo, help2man
+Requires:       SDL, SDL_image, SDL_ttf, openal-soft, alsa-lib, alsa-plugins-pulseaudio, mesa-dri-drivers, python, gnome-terminal, java-1.8.0-openjdk, python3-tkinter, qt5-qttools
 
 %description
 A ready-to-go rpm package of McArcady's Lazy Newb Pack for Dwarf Fortress


### PR DESCRIPTION
While tinkering with your package to get it working on Fedora, I decided to build an rpm package for it, which should make it easier for other Fedora users to install (among other things, this package sets the terminal command used by PyLNP, as for some reason PyLNP is incapable of detecting the terminal on Fedora and guessing which command should be used for it turned out to be really bothersome, speaking from experience here :laughing: ). I've also added some instructions on README explaining how the package should be built.

Additionally, please consider changing the list of dependencies listed for Fedora in the wiki to replace `tkinter` with `python3-tkinter`, as `tkinter` doesn't exist as a package. If possible I'd do so myself but I don't have write access to the wiki.

I've also added a minor edit on the commands present in the readme.