### PR TITLE
Add weekly builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build LinuxDwarfPack package
 on:
   push:
   pull_request:
+  schedule:
+    - cron: '0 0 * * 1'
 
 jobs:
   build:


### PR DESCRIPTION
#27 highlighted that currently the build process relies on external stuff. This PR adds a weekly scheduled build that will make sure that if something breaks an alert will go off at some point.