### PR TITLE
Add support for new getcap output format

### DIFF
--- a/patches/lnp/0.10f/400-startlnp-script.patch
+++ b/patches/lnp/0.10f/400-startlnp-script.patch
@@ -11,7 +11,7 @@ diff -duN lnp-0.10f.orig/startlnp.sh lnp-0.10f/startlnp.sh
 +
 +if [ -x /sbin/getcap ] && [ -x /sbin/setcap ]; then
 +    #Check whether Dwarf Therapist can read from DF memory:
-+    dt_capabilities=$(/sbin/getcap bin/DwarfTherapist |cut -f2 -d"="|tr -d " ")
++    dt_capabilities=$(/sbin/getcap bin/DwarfTherapist | sed -r 's|^[a-zA-Z0-9/_-]+[ =]+([a-z0-9_]+,)*(cap_sys_ptrace)(,[a-z0-9_]+)*[=+]([eip]+)$|\2+\4|')
 +    dt_capabilities=${dt_capabilities:=0}
 +    if [ ${dt_capabilities} != "cap_sys_ptrace+eip" ]; then
 +        msg="Enable Dwarf Therapist to read from Dwarf Fortress memory"

--- a/patches/lnp/0.12a/400-startlnp-script.patch
+++ b/patches/lnp/0.12a/400-startlnp-script.patch
@@ -11,7 +11,7 @@ diff -duN lnp-0.10f.orig/startlnp.sh lnp-0.10f/startlnp.sh
 +
 +if [ -x /sbin/getcap ] && [ -x /sbin/setcap ]; then
 +    #Check whether Dwarf Therapist can read from DF memory:
-+    dt_capabilities=$(/sbin/getcap bin/DwarfTherapist |cut -f2 -d"="|tr -d " ")
++    dt_capabilities=$(/sbin/getcap bin/DwarfTherapist | sed -r 's|^[a-zA-Z0-9/_-]+[ =]+([a-z0-9_]+,)*(cap_sys_ptrace)(,[a-z0-9_]+)*[=+]([eip]+)$|\2+\4|')
 +    dt_capabilities=${dt_capabilities:=0}
 +    if [ ${dt_capabilities} != "0" -a ${dt_capabilities} != "cap_sys_ptrace+eip" ]; then
 +        msg="Enable Dwarf Therapist to read from Dwarf Fortress memory"

--- a/patches/lnp/0.13/400-startlnp-script.patch
+++ b/patches/lnp/0.13/400-startlnp-script.patch
@@ -11,7 +11,7 @@ diff -duN lnp-0.10f.orig/startlnp.sh lnp-0.10f/startlnp.sh
 +
 +if [ -x /sbin/getcap ] && [ -x /sbin/setcap ]; then
 +    #Check whether Dwarf Therapist can read from DF memory:
-+    dt_capabilities=$(/sbin/getcap bin/DwarfTherapist |cut -f2 -d"="|tr -d " ")
++    dt_capabilities=$(/sbin/getcap bin/DwarfTherapist | sed -r 's|^[a-zA-Z0-9/_-]+[ =]+([a-z0-9_]+,)*(cap_sys_ptrace)(,[a-z0-9_]+)*[=+]([eip]+)$|\2+\4|')
 +    dt_capabilities=${dt_capabilities:=0}
 +    if [ ${dt_capabilities} != "0" -a ${dt_capabilities} != "cap_sys_ptrace+eip" ]; then
 +        msg="Enable Dwarf Therapist to read from Dwarf Fortress memory"

--- a/patches/lnp/default/400-startlnp-script.patch
+++ b/patches/lnp/default/400-startlnp-script.patch
@@ -11,7 +11,7 @@ diff -duN lnp-0.10f.orig/startlnp.sh lnp-0.10f/startlnp.sh
 +
 +if [ -x /sbin/getcap ] && [ -x /sbin/setcap ]; then
 +    #Check whether Dwarf Therapist can read from DF memory:
-+    dt_capabilities=$(/sbin/getcap bin/dwarftherapist |cut -f2 -d"="|tr -d " ")
++    dt_capabilities=$(/sbin/getcap bin/dwarftherapist | sed -r 's|^[a-zA-Z0-9/_-]+[ =]+([a-z0-9_]+,)*(cap_sys_ptrace)(,[a-z0-9_]+)*[=+]([eip]+)$|\2+\4|')
 +    dt_capabilities=${dt_capabilities:=0}
 +    if [ ${dt_capabilities} != "0" -a ${dt_capabilities} != "cap_sys_ptrace+eip" ]; then
 +        msg="Enable Dwarf Therapist to read from Dwarf Fortress memory"


### PR DESCRIPTION
Use `sed -r` in `startlnp.sh` scripts to convert new `getcap` output format to old one.

Newer `getcap bin/dwarftherapist` returns `bin/dwarftherapist cap_sys_ptrace=eip` while old one returns `bin/dwarftherapist = cap_sys_ptrace+eip`.

Fixes #84